### PR TITLE
Configuration gets overwritten by js and sass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @studyportals/product-deploy@v2.2.5
+# @studyportals/product-deploy@v2.2.6
 
 <a href="https://www.npmjs.com/package/@studyportals/product-deploy" title="View this project on NPM" target="_blank"><img src="https://img.shields.io/npm/v/@studyportals/product-deploy.svg?style=flat" alt="NPM version" /></a>
 <a href="https://www.npmjs.com/package/@studyportals/product-deploy" title="View this project on NPM" target="_blank"><img src="https://img.shields.io/npm/l/@studyportals/product-deploy.svg?style=flat" alt="NPM license" /></a>
@@ -220,4 +220,4 @@ Tasks:
 | opts.buildDir | <code>string</code> | 
 
 
-_README.md generated at: Thu Sep 21 2017 23:48:15 GMT+0200 (CEST)_
+_README.md generated at: Fri Sep 22 2017 11:05:25 GMT+0200 (CEST)_

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -131,13 +131,13 @@ class Deploy {
 
 		const sp_sass = require('./private/sass');
 		return sp_sass.compile({
-			'base': this.opts.from,
+			'base': this.opts.to,
 			'from': [
-				`${this.opts.from}/**/*.scss`,
-				`!${this.opts.from}/test/**/*`,
-				`!${this.opts.from}/bower_components/**/*`,
-				`!${this.opts.from}/node_modules/**/*`,
-				`!${this.opts.from}/vendor/**/*`,
+				`${this.opts.to}/**/*.scss`,
+				`!${this.opts.to}/test/**/*`,
+				`!${this.opts.to}/bower_components/**/*`,
+				`!${this.opts.to}/node_modules/**/*`,
+				`!${this.opts.to}/vendor/**/*`,
 			],
 			to: this.opts.to,
 			compress: this.enableCompression,
@@ -160,13 +160,13 @@ class Deploy {
 	 */
 	js(){
 		return require('./private/js').compile({
-			base: this.opts.from,
+			base: this.opts.to,
 			from: [
-				`${this.opts.from}/**/*.js`,
-				`!${this.opts.from}/test/**/*`,
-				`!${this.opts.from}/bower_components/**/*`,
-				`!${this.opts.from}/node_modules/**/*`,
-				`!${this.opts.from}/vendor/**/*`,
+				`${this.opts.to}/**/*.js`,
+				`!${this.opts.to}/test/**/*`,
+				`!${this.opts.to}/bower_components/**/*`,
+				`!${this.opts.to}/node_modules/**/*`,
+				`!${this.opts.to}/vendor/**/*`,
 			],
 			to: this.opts.to,
 			uglify: this.enableCompression

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studyportals/product-deploy",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "Toolset to deploy StudyPortals products",
   "author": "StudyPortals B.V.",
   "scripts": {


### PR DESCRIPTION
The configuration files are overwritten when `js` and `sass` steps are executed. This happens because these steps take the files in the source location and overwrite them in the dest location. Already overwritten files by the configuration step get lost because of this.