### PR TITLE
Compile assets in dist folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @studyportals/product-deploy@v2.3.0-alpha.1
+# @studyportals/product-deploy@v2.3.0
 
 <a href="https://www.npmjs.com/package/@studyportals/product-deploy" title="View this project on NPM" target="_blank"><img src="https://img.shields.io/npm/v/@studyportals/product-deploy.svg?style=flat" alt="NPM version" /></a>
 <a href="https://www.npmjs.com/package/@studyportals/product-deploy" title="View this project on NPM" target="_blank"><img src="https://img.shields.io/npm/l/@studyportals/product-deploy.svg?style=flat" alt="NPM license" /></a>
@@ -74,8 +74,8 @@ Toolset to deploy StudyPortals products
     * [.configure()](#Deploy+configure) ⇒ <code>Promise</code>
     * [.composer()](#Deploy+composer) ⇒ <code>Promise</code>
     * [.prepare()](#Deploy+prepare) ⇒ <code>Promise</code>
-    * [.sass()](#Deploy+sass) ⇒ <code>Promise</code>
-    * [.js()](#Deploy+js) ⇒ <code>Promise</code>
+    * [.sass(from)](#Deploy+sass) ⇒ <code>Promise</code>
+    * [.js(from)](#Deploy+js) ⇒ <code>Promise</code>
     * [.startWatchers()](#Deploy+startWatchers) ⇒ <code>undefined</code>
 
 <a name="new_Deploy_new"></a>
@@ -135,7 +135,7 @@ It makes sure the folder exists and is empty.
 **Kind**: instance method of [<code>Deploy</code>](#Deploy)  
 <a name="Deploy+sass"></a>
 
-### deploy.sass() ⇒ <code>Promise</code>
+### deploy.sass(from) ⇒ <code>Promise</code>
 Compile scss files into css.
 
 Takes all `*.scss` files excluding the folders:
@@ -145,9 +145,14 @@ Takes all `*.scss` files excluding the folders:
 - vendor
 
 **Kind**: instance method of [<code>Deploy</code>](#Deploy)  
+
+| Param | Type |
+| --- | --- |
+| from | <code>Array.&lt;glob&gt;</code> \| <code>string</code> | 
+
 <a name="Deploy+js"></a>
 
-### deploy.js() ⇒ <code>Promise</code>
+### deploy.js(from) ⇒ <code>Promise</code>
 Compile js files (babel and uglify)
 
 Takes all `*.js` files excluding the folders:
@@ -160,6 +165,11 @@ First it will pipe them through babel. When `Deploy.enableCompression` is
 true it will also uglyfies them.
 
 **Kind**: instance method of [<code>Deploy</code>](#Deploy)  
+
+| Param | Type |
+| --- | --- |
+| from | <code>Array.&lt;glob&gt;</code> \| <code>string</code> | 
+
 <a name="Deploy+startWatchers"></a>
 
 ### deploy.startWatchers() ⇒ <code>undefined</code>
@@ -223,4 +233,4 @@ Tasks:
 | opts.buildDir | <code>string</code> | 
 
 
-_README.md generated at: Wed Sep 27 2017 15:16:13 GMT+0200 (CEST)_
+_README.md generated at: Wed Sep 27 2017 15:26:17 GMT+0200 (CEST)_

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @studyportals/product-deploy@v2.2.9
+# @studyportals/product-deploy@v2.3.0-alpha.1
 
 <a href="https://www.npmjs.com/package/@studyportals/product-deploy" title="View this project on NPM" target="_blank"><img src="https://img.shields.io/npm/v/@studyportals/product-deploy.svg?style=flat" alt="NPM version" /></a>
 <a href="https://www.npmjs.com/package/@studyportals/product-deploy" title="View this project on NPM" target="_blank"><img src="https://img.shields.io/npm/l/@studyportals/product-deploy.svg?style=flat" alt="NPM license" /></a>
@@ -223,4 +223,4 @@ Tasks:
 | opts.buildDir | <code>string</code> | 
 
 
-_README.md generated at: Tue Sep 26 2017 17:21:52 GMT+0200 (CEST)_
+_README.md generated at: Wed Sep 27 2017 15:16:13 GMT+0200 (CEST)_

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -189,12 +189,6 @@ class Deploy{
 	 */
 	startWatchers(){
 
-		if(require('is-wsl')){
-
-			// @see https://github.com/paulmillr/chokidar/issues/532
-			log.warning(`file watchers are buggy on Windows Subsystem for Linux. Use them at your own responsibility.`);
-		}
-
 		const disabledWatchers = [];
 		if(process.env.PRTL_DISABLED_WATCHERS){
 
@@ -208,6 +202,12 @@ class Deploy{
 
 			// All disabled, nothing to do.
 			return;
+		}
+
+		if(require('is-wsl')){
+
+			// @see https://github.com/paulmillr/chokidar/issues/532
+			log.warning(`file watchers are buggy on Windows Subsystem for Linux. Use them at your own responsibility.`);
 		}
 
 		const chokidar = require('chokidar');

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -41,6 +41,14 @@ class Deploy{
 			throw new Error(`${this.constructor.name}: Incorrect process.env.PRTL_ENV: '${process.env.PRTL_ENV}', available options: ${valid_envs.concat(', ')}`);
 		}
 
+		this.distFolder = this.opts.to;
+
+		// TODO: Better name for this env var.
+		if(process.env.PRTL_USE_DIST_FOLDER){
+
+			this.distFolder = path.resolve(this.distFolder, 'dist');
+		}
+
 		this.enableCompression = process.env.PRTL_ENV === env.PRD || process.env.PRTL_ENV === env.STG;
 
 		if(this.opts.gulp){
@@ -145,7 +153,7 @@ class Deploy{
 		return sass.compile({
 			base: this.opts.to,
 			from,
-			to: path.resolve(this.opts.to, 'dist'),
+			to: this.distFolder,
 			compress: this.enableCompression,
 		});
 	};
@@ -179,7 +187,7 @@ class Deploy{
 		return require('./private/js').compile({
 			base: this.opts.to,
 			from,
-			to: path.resolve(this.opts.to, 'dist'),
+			to: this.distFolder,
 			uglify: this.enableCompression
 		});
 	};

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -130,17 +130,21 @@ class Deploy{
 	 *
 	 * @return {Promise}
 	 */
-	sass(){
+	sass(from){
+
+		// todo: add param to jsdoc
+
+		from = from || [
+			`${this.opts.to}/**/*.scss`,
+			`!${this.opts.to}/test/**/*`,
+			`!${this.opts.to}/bower_components/**/*`,
+			`!${this.opts.to}/node_modules/**/*`,
+			`!${this.opts.to}/vendor/**/*`,
+		];
 
 		return sass.compile({
-			'base': this.opts.to,
-			'from': [
-				`${this.opts.to}/**/*.scss`,
-				`!${this.opts.to}/test/**/*`,
-				`!${this.opts.to}/bower_components/**/*`,
-				`!${this.opts.to}/node_modules/**/*`,
-				`!${this.opts.to}/vendor/**/*`,
-			],
+			base: this.opts.to,
+			from,
 			to: path.resolve(this.opts.to, 'dist'),
 			compress: this.enableCompression,
 		});
@@ -160,17 +164,22 @@ class Deploy{
 	 *
 	 * @return {Promise}
 	 */
-	js(){
+	js(from){
+
+		// todo: add param to jsdoc
+
+		from = from || [
+			`${this.opts.to}/**/*.js`,
+			`!${this.opts.to}/test/**/*`,
+			`!${this.opts.to}/bower_components/**/*`,
+			`!${this.opts.to}/node_modules/**/*`,
+			`!${this.opts.to}/vendor/**/*`,
+		];
+
 		return require('./private/js').compile({
 			base: this.opts.to,
-			from: [
-				`${this.opts.to}/**/*.js`,
-				`!${this.opts.to}/test/**/*`,
-				`!${this.opts.to}/bower_components/**/*`,
-				`!${this.opts.to}/node_modules/**/*`,
-				`!${this.opts.to}/vendor/**/*`,
-			],
-			to: this.opts.to,
+			from,
+			to: path.resolve(this.opts.to, 'dist'),
 			uglify: this.enableCompression
 		});
 	};
@@ -254,12 +263,7 @@ class Deploy{
 				case '.js':
 
 					log.info(`File changed: ${filePath}, compiling js`);
-					return require('./private/js').compile({
-						base: self.opts.from,
-						from: filePath,
-						to: self.opts.to,
-						uglify: self.enableCompression
-					})
+					return self.js(filePath)
 					.catch(exc => { throw exc; });
 
 					break;
@@ -294,12 +298,7 @@ class Deploy{
 
 							addDepencenciesRecursive([filePath]);
 
-							return sass.compile({
-								base: self.opts.from,
-								from: dependencies,
-								to: path.resolve(self.opts.to, 'dist'),
-								compress: self.enableCompression
-							});
+							return self.sass(dependencies);
 						})
 						.then(() => {
 

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -3,6 +3,7 @@
 const env = require('./private/env');
 const log = require('@studyportals/node-log');
 const sass = require('./private/sass');
+const path = require('path');
 
 /**
  * @type {Deploy}
@@ -140,7 +141,7 @@ class Deploy{
 				`!${this.opts.to}/node_modules/**/*`,
 				`!${this.opts.to}/vendor/**/*`,
 			],
-			to: this.opts.to,
+			to: path.resolve(this.opts.to, 'dist'),
 			compress: this.enableCompression,
 		});
 	};
@@ -211,7 +212,6 @@ class Deploy{
 
 		const chokidar = require('chokidar');
 		const gulp = this.opts.gulp;
-		const path = require('path');
 		const self = this;
 
 		const ignored = [
@@ -297,7 +297,7 @@ class Deploy{
 							return sass.compile({
 								base: self.opts.from,
 								from: dependencies,
-								to: self.opts.to,
+								to: path.resolve(self.opts.to, 'dist'),
 								compress: self.enableCompression
 							});
 						})

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -136,11 +136,11 @@ class Deploy{
 	 * - node_modules
 	 * - vendor
 	 *
+	 * @param {glob[]|string} from
+	 *
 	 * @return {Promise}
 	 */
 	sass(from){
-
-		// todo: add param to jsdoc
 
 		from = from || [
 			`${this.opts.to}/**/*.scss`,
@@ -170,11 +170,11 @@ class Deploy{
 	 * First it will pipe them through babel. When `Deploy.enableCompression` is
 	 * true it will also uglyfies them.
 	 *
+	 * @param {glob[]|string} from
+	 *
 	 * @return {Promise}
 	 */
 	js(from){
-
-		// todo: add param to jsdoc
 
 		from = from || [
 			`${this.opts.to}/**/*.js`,

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -43,7 +43,7 @@ class Deploy{
 
 		this.distFolder = this.opts.to;
 
-		// TODO: Better name for this env var.
+		// @deprecated - Make default in the next MAJOR release.
 		if(process.env.PRTL_USE_DIST_FOLDER){
 
 			this.distFolder = path.resolve(this.distFolder, 'dist');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@studyportals/product-deploy",
-  "version": "2.3.0-alpha.1",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@studyportals/product-deploy",
-  "version": "2.2.9",
+  "version": "2.3.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studyportals/product-deploy",
-  "version": "2.3.0-alpha.1",
+  "version": "2.3.0",
   "description": "Toolset to deploy StudyPortals products",
   "author": "StudyPortals B.V.",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studyportals/product-deploy",
-  "version": "2.2.9",
+  "version": "2.3.0-alpha.1",
   "description": "Toolset to deploy StudyPortals products",
   "author": "StudyPortals B.V.",
   "scripts": {

--- a/test/deploy/js.js
+++ b/test/deploy/js.js
@@ -18,7 +18,7 @@ module.exports = function(Deploy){
 
 		return Deploy.js()
 			.then(() =>{
-				chai.expect(path.join(Deploy.opts.to, 'js/code.js')).to.be.a.file();
+				chai.expect(path.join(Deploy.opts.to, 'dist/js/code.js')).to.be.a.file();
 			});
 	});
 };

--- a/test/deploy/js.js
+++ b/test/deploy/js.js
@@ -18,7 +18,7 @@ module.exports = function(Deploy){
 
 		return Deploy.js()
 			.then(() =>{
-				chai.expect(path.join(Deploy.opts.to, 'dist/js/code.js')).to.be.a.file();
+				chai.expect(path.join(Deploy.distFolder, 'js/code.js')).to.be.a.file();
 			});
 	});
 };

--- a/test/deploy/sass.js
+++ b/test/deploy/sass.js
@@ -18,7 +18,7 @@ module.exports = function(Deploy){
 
 		return Deploy.sass()
 			.then(() =>{
-				chai.expect(path.join(Deploy.opts.to, 'dist/css/style.css')).to.be.a.file();
+				chai.expect(path.join(Deploy.distFolder, 'css/style.css')).to.be.a.file();
 			});
 	});
 };

--- a/test/deploy/sass.js
+++ b/test/deploy/sass.js
@@ -18,7 +18,7 @@ module.exports = function(Deploy){
 
 		return Deploy.sass()
 			.then(() =>{
-				chai.expect(path.join(Deploy.opts.to, 'css/style.css')).to.be.a.file();
+				chai.expect(path.join(Deploy.opts.to, 'dist/css/style.css')).to.be.a.file();
 			});
 	});
 };


### PR DESCRIPTION
`js` and `scss` are at the moment compiled in the deploy-location while maintaining the folder structure. When we deploy in the git repository it would mean that these files will be overwritten and thus committed into git. This is not desired. Better would be to compile them into a `dist` (or `public` or whatever accessible) folder. This can easily be changes in the [sass](https://github.com/studyportals/product-deploy/blob/0421aad928fb2658ee7b998290ea2a050651b245/lib/deploy.js#L132) and [js](https://github.com/studyportals/product-deploy/blob/0421aad928fb2658ee7b998290ea2a050651b245/lib/deploy.js#L162) step.
The first step is to compile them into a `dist` folder inside the deploy location.

Idea:
- [x] Make it optional by setting an env var (inside the Gulpfile.js) this way we do not need to bump the Major version but can bump the Minor version. Later on we can make it the standard and remove the env var in a Major release.

Dependencies:
- [x] https://github.com/studyportals/Meta-Config/pull/75
- [x] https://github.com/studyportals/CMS/pull/141

This needs to be changed when we bump a product to this version:
- [x] Make sure https://github.com/studyportals/CMS/pull/141 is loaded via composer.
- [ ] Rewrite missing css/js to dist folder for [.ebextension](https://github.com/studyportals/Bachelors/blob/develop/.ebextensions/02-httpd-rewrite.config)
@see https://github.com/studyportals/Bachelors/pull/261/commits/4784427f147483b4fbdfaaae0bedc884bb3860ae
- [ ] Set the env var `process.env.PRTL_USE_DIST_FOLDER = 'true';` in `Gulpfile.js` to enable this feature.