### PR TITLE
Patch js watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @studyportals/product-deploy@v3.0.2-0
+# @studyportals/product-deploy@v3.0.2
 
 <a href="https://www.npmjs.com/package/@studyportals/product-deploy" title="View this project on NPM" target="_blank"><img src="https://img.shields.io/npm/v/@studyportals/product-deploy.svg?style=flat" alt="NPM version" /></a>
 <a href="https://www.npmjs.com/package/@studyportals/product-deploy" title="View this project on NPM" target="_blank"><img src="https://img.shields.io/npm/l/@studyportals/product-deploy.svg?style=flat" alt="NPM license" /></a>
@@ -98,4 +98,4 @@ Behaviour can be changed by changing these env vars:
 | gulp | <code>Gulp</code> | 
 
 
-_README.md generated at: Mon Oct 23 2017 14:23:25 GMT+0200 (CEST)_
+_README.md generated at: Mon Oct 23 2017 14:27:44 GMT+0200 (CEST)_

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @studyportals/product-deploy@v3.0.1
+# @studyportals/product-deploy@v3.0.2-0
 
 <a href="https://www.npmjs.com/package/@studyportals/product-deploy" title="View this project on NPM" target="_blank"><img src="https://img.shields.io/npm/v/@studyportals/product-deploy.svg?style=flat" alt="NPM version" /></a>
 <a href="https://www.npmjs.com/package/@studyportals/product-deploy" title="View this project on NPM" target="_blank"><img src="https://img.shields.io/npm/l/@studyportals/product-deploy.svg?style=flat" alt="NPM license" /></a>
@@ -98,4 +98,4 @@ Behaviour can be changed by changing these env vars:
 | gulp | <code>Gulp</code> | 
 
 
-_README.md generated at: Mon Oct 23 2017 12:13:27 GMT+0200 (CEST)_
+_README.md generated at: Mon Oct 23 2017 14:23:25 GMT+0200 (CEST)_

--- a/lib/private/deploy.js
+++ b/lib/private/deploy.js
@@ -216,6 +216,11 @@ class Deploy{
 		};
 		opts = Object.assign(defaults, opts);
 
+		if(typeof opts.from === 'string'){
+
+			opts.from = [opts.from];
+		}
+
 		opts.from = opts.from.concat(this._getIgnoredFolders(true));
 
 		return sass.compile({
@@ -254,6 +259,11 @@ class Deploy{
 			'progress': true
 		};
 		opts = Object.assign(defaults, opts);
+
+		if(typeof opts.from === 'string'){
+
+			opts.from = [opts.from];
+		}
 
 		opts.from = opts.from.concat(this._getIgnoredFolders(true));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@studyportals/product-deploy",
-  "version": "3.0.1",
+  "version": "3.0.2-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@studyportals/product-deploy",
-  "version": "3.0.2-0",
+  "version": "3.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studyportals/product-deploy",
-  "version": "3.0.2-0",
+  "version": "3.0.2",
   "description": "Toolset to deploy StudyPortals products",
   "author": "StudyPortals B.V.",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studyportals/product-deploy",
-  "version": "3.0.1",
+  "version": "3.0.2-0",
   "description": "Toolset to deploy StudyPortals products",
   "author": "StudyPortals B.V.",
   "scripts": {


### PR DESCRIPTION
The JS compilation step is working when an array is passed as `opts.from` in case of an string if broke because we concat the ignored folder. Concatenation an array to a string resulted into one big string instead of an array with items.